### PR TITLE
Add arenaID only healthbar text status option

### DIFF
--- a/TidyPlatesHub/functions/Text.lua
+++ b/TidyPlatesHub/functions/Text.lua
@@ -177,8 +177,27 @@ local function HealthFunctionLevelHealth(unit)
 end
 
 
--- Arena Vitals (ID, Mana, Health
+-- Arena ID
 local function HealthFunctionArenaID(unit)
+	local arenastring = ""
+	local arenaindex = GetArenaIndex(unit.rawName)
+
+	--arenaindex = 2	-- Tester
+	if unit.type == "PLAYER" then
+
+		if arenaindex and arenaindex > 0 then
+			arenastring = "|cffff0000"..(tostring(arenaindex)).." |r"
+		end
+
+	end
+
+	return arenastring
+
+end
+
+
+-- Arena Vitals (ID, Mana, Health)
+local function HealthFunctionArenaIDHealthPower(unit)
 	local localid
 	local powercolor = White
 	local powerstring = ""
@@ -234,7 +253,6 @@ local function HealthFunctionArenaID(unit)
 
 	--]]
 end
-
 
 local HealthTextModesCustom = {}
 
@@ -320,7 +338,8 @@ AddHubFunction(HealthTextModeFunctions, TidyPlatesHubMenus.TextModes, HealthFunc
 AddHubFunction(HealthTextModeFunctions, TidyPlatesHubMenus.TextModes, HealthFunctionTargetOf, "Target Of", "HealthFunctionTargetOf")
 AddHubFunction(HealthTextModeFunctions, TidyPlatesHubMenus.TextModes, HealthFunctionLevel, "Level", "HealthFunctionLevel")
 AddHubFunction(HealthTextModeFunctions, TidyPlatesHubMenus.TextModes, HealthFunctionLevelHealth, "Level and Approx Health", "HealthFunctionLevelHealth")
-AddHubFunction(HealthTextModeFunctions, TidyPlatesHubMenus.TextModes, HealthFunctionArenaID, "Arena ID, Health, and Power", "HealthFunctionArenaID")
+AddHubFunction(HealthTextModeFunctions, TidyPlatesHubMenus.TextModes, HealthFunctionArenaID, "Arena ID", "HealthFunctionArenaID")
+AddHubFunction(HealthTextModeFunctions, TidyPlatesHubMenus.TextModes, HealthFunctionArenaIDHealthPower, "Arena ID, Health, and Power", "HealthFunctionArenaIDHealthPower")
 
 
 local function HealthTextDelegate(unit)


### PR DESCRIPTION
As a player who uses @arena1/@arena2/@arena3 macros, I strongly rely on seeing the arena numbers clear. The existing option with health and mana is providing too much information.

Here is a [very simple addon](https://www.curseforge.com/wow/addons/arena-nameplate-numbers) showing just the arena numbers and it's quite popular, considering it only does one thing. Unfortunately, it only works with default blizzard nameplates, so I thought adding the option to your addon would be cool.

Screenshot to showcase that the new option is working:
![image](https://github.com/user-attachments/assets/3409fb74-2708-444a-aa74-e658ad35405f)
